### PR TITLE
fix: 修复原有LottieView组件销毁时使用itemAnimate.destroy释放动画改为lottie.destroy导致潜在的内存泄漏问题。

### DIFF
--- a/harmony/lottie/oh-package.json5
+++ b/harmony/lottie/oh-package.json5
@@ -9,6 +9,6 @@
   "version": "6.4.1-0.1.5",
   "dependencies": {
     "@rnoh/react-native-openharmony": "file:../react_native_openharmony",
-    "@ohos/lottie": "2.0.11-rc.3"
+    "@ohos/lottie": "2.0.11-rc.6"
   }
 }

--- a/harmony/lottie/src/main/ets/Logger.ts
+++ b/harmony/lottie/src/main/ets/Logger.ts
@@ -1,0 +1,64 @@
+/**
+ * MIT License
+ *
+ * Copyright (C) 2024 Huawei Device Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import hilog from '@ohos.hilog';
+
+class Logger {
+  private domain: number;
+  private prefix: string;
+  private format: string = '%{public}s, %{public}s';
+  private isDebug: boolean;
+
+  /**
+   * constructor.
+   *
+   * @param Prefix Identifies the log tag.
+   * @param domain Domain Indicates the service domain, which is a hexadecimal integer ranging from 0x0 to 0xFFFFF.
+   */
+  constructor(prefix: string = 'Lottie', domain: number = 0xFF00, isDebug = false) {
+    this.prefix = prefix;
+    this.domain = domain;
+    this.isDebug = isDebug;
+  }
+
+  debug(...args: string[]): void {
+    if (this.isDebug) {
+      hilog.debug(this.domain, this.prefix, this.format, args);
+    }
+  }
+
+  info(...args: string[]): void {
+    hilog.info(this.domain, this.prefix, this.format, args);
+  }
+
+  warn(...args: string[]): void {
+    hilog.warn(this.domain, this.prefix, this.format, args);
+  }
+
+  error(...args: string[]): void {
+    hilog.error(this.domain, this.prefix, this.format, args);
+  }
+}
+
+export default new Logger('Lottie', 0xFF00, false);

--- a/harmony/lottie/src/main/ets/LottieAnimationView.ets
+++ b/harmony/lottie/src/main/ets/LottieAnimationView.ets
@@ -22,6 +22,7 @@ import { AnimationObject, LottieViewProps } from './common/AnimationType'
 import { LottieCompositionCache } from './LottieCompositionCache'
 import { convertImageFolder } from './LottieAnimationTools'
 import { getHashCode } from './common/TextUtils'
+import Logger from './Logger';
 
 export const LOTTIE_TYPE: string = "LottieAnimationView"
 
@@ -44,7 +45,8 @@ export struct LottieAnimationView {
   private renderingSettings: RenderingContextSettings = new RenderingContextSettings(true)
   private canvasRenderingContext: CanvasRenderingContext2D = new CanvasRenderingContext2D(this.renderingSettings)
   private animateItem: AnimationItem | null = null
-  private lottieCache = LottieCompositionCache.getInstance()
+  private lottieCache = LottieCompositionCache.getInstance();
+  private animateKey: string | null = null;
 
   aboutToAppear() {
     this.descriptor = this.ctx.descriptorRegistry.getDescriptor<LottieViewDescriptor>(this.tag)
@@ -56,7 +58,11 @@ export struct LottieAnimationView {
   aboutToDisappear() {
     this.cleanupCommandCallback?.()
     this.unregisterDescriptorChangesListener?.()
-    this.destroyAnimation()
+    this.destroyAnimation();
+    if (this.animateKey) {
+      lottie.destroy(this.animateKey);
+    }
+    this.animateKey = null;
   }
 
   subscribeToDescriptorChanges(): void {
@@ -151,17 +157,17 @@ export struct LottieAnimationView {
   }
 
   request(url: string, hashCode?: string): void {
-    console.info('httpRequest.request url:' + JSON.stringify(url))
+    Logger.debug('httpRequest.request url:' + JSON.stringify(url))
     const httpRequest = http.createHttp()
     httpRequest.request(url, { header: { 'Content-Type': 'application/json' } }, (err, data) => {
       if (err == undefined && data != undefined) {
-        console.info('httpRequest.request success:' + JSON.stringify(data))
+        Logger.debug('httpRequest.request success:' + JSON.stringify(data))
         const result: Object = data.result
         if (result) {
           this.updateJsonData(result as string, hashCode)
         }
       } else {
-        console.info('httpRequest.request error:' + JSON.stringify(err))
+        Logger.error('httpRequest.request error:' + JSON.stringify(err))
       }
     })
   }
@@ -211,15 +217,17 @@ export struct LottieAnimationView {
     if (this.animateItem.isPaused === false) {
       this.onAnimationEnd()
     }
-    this.animateItem.destroy()
+    lottie.destroy(this.animateKey);
     this.animateItem = null
   }
 
   loadAnimation(): void {
     this.destroyAnimation()
+    this.animateKey = `${this.tag}${new Date().getTime()}`;
     this.animateItem = lottie.loadAnimation({
       container: this.canvasRenderingContext,
       renderer: 'canvas',
+      name: this.animateKey,
       loop: Boolean(this.descriptor.props.loop),
       autoplay: Boolean(this.descriptor.props.autoPlay),
       animationData: this.jsonData


### PR DESCRIPTION
fix: animationItem.destroy可能会导致动画、内存泄漏会对主线程一直有影响，本次将原有LottieView组件销毁时使用itemAnimate.destroy释放动画改为lottie.destroy，修复了潜在的内存泄漏问题。