### PR TITLE
fix:升级依赖的arkTS lottie库为2.0.19版本，解决progress设置1动画不移动问题

### DIFF
--- a/harmony/lottie/oh-package.json5
+++ b/harmony/lottie/oh-package.json5
@@ -9,6 +9,6 @@
   "version": "6.4.1-0.1.16",
   "dependencies": {
     "@rnoh/react-native-openharmony": "^0.72.38",
-    "@ohos/lottie": "2.0.17"
+    "@ohos/lottie": "2.0.19"
   }
 }


### PR DESCRIPTION


# Summary

fix:升级依赖的arkTS lottie库为2.0.19版本，解决progress设置1动画不移动问题，和维护arkTS lottie沟通后是可直接升级的


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

